### PR TITLE
Fix completion status and provider pool integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.0
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
-
-      - name: Enable pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@11.1.0 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "pnpm"

--- a/apps/extension/src/background/agent/agent-broadcast.ts
+++ b/apps/extension/src/background/agent/agent-broadcast.ts
@@ -187,11 +187,13 @@ export function successfulTaskCompletionMessage(args: {
   const subtaskResults: SubtaskResult[] = args.subtasks.map((st) => ({
     description: st.description,
     status:
-      st.status === "failed"
-        ? ("failed" as const)
-        : st.status === "skipped"
-          ? ("skipped" as const)
-          : ("completed" as const),
+      st.status === "completed"
+        ? ("completed" as const)
+        : st.status === "failed"
+          ? ("failed" as const)
+          : st.status === "skipped"
+            ? ("skipped" as const)
+            : ("stopped" as const),
     turnsUsed: st.turnsUsed,
     result: st.result || "",
   }));
@@ -200,9 +202,7 @@ export function successfulTaskCompletionMessage(args: {
     type: "TASK_COMPLETION",
     payload: {
       taskId: args.taskId,
-      status: subtaskResults.every((sr) => sr.status === "completed")
-        ? "completed"
-        : "partial",
+      status: "completed",
       totalTurnsUsed: args.turnCount,
       totalTimeMs: args.totalTimeMs,
       summary: args.summary,

--- a/apps/extension/src/background/agent/agent-plan-progress.ts
+++ b/apps/extension/src/background/agent/agent-plan-progress.ts
@@ -34,6 +34,22 @@ export function buildInitialPlanSubtasks(
   }));
 }
 
+export function annotateCompletedPlanSubtasksForAcceptedDone(args: {
+  subtasks: Pick<SubtaskSummary, "status" | "result">[];
+  summary: string;
+}): void {
+  for (const subtask of args.subtasks) {
+    if (subtask.status === "completed" && !subtask.result) {
+      subtask.result = "Completed";
+    }
+  }
+
+  const lastSubtask = args.subtasks[args.subtasks.length - 1];
+  if (lastSubtask?.status === "completed") {
+    lastSubtask.result = args.summary.slice(0, 200);
+  }
+}
+
 export function buildRestoredPlanState(
   initialPlanState: RestorablePlanState,
 ): {

--- a/apps/extension/src/background/agent/completion-evaluation-service.ts
+++ b/apps/extension/src/background/agent/completion-evaluation-service.ts
@@ -1,0 +1,43 @@
+import type { DomSnapshot } from "../../types";
+import {
+  evaluateCompletionContract,
+  generateCompletionContract,
+  type CompletionCandidateSource,
+  type CompletionEvaluation,
+  type CompletionEvidence,
+  type GeneratedCompletionContract,
+} from "./completion-kernel";
+
+export interface GeneratedCompletionEvaluationRequest {
+  userRequest: string;
+  snapshot: DomSnapshot | null | undefined;
+  activeObjective?: string;
+  successCriteria?: string;
+  evidence: CompletionEvidence[];
+  candidateSource: CompletionCandidateSource;
+  summary?: string;
+}
+
+export interface GeneratedCompletionEvaluationResult {
+  generated: GeneratedCompletionContract | null;
+  decision: CompletionEvaluation;
+}
+
+export function evaluateGeneratedCompletionCandidate(
+  request: GeneratedCompletionEvaluationRequest,
+): GeneratedCompletionEvaluationResult {
+  const generated = generateCompletionContract({
+    userRequest: request.userRequest,
+    snapshot: request.snapshot,
+    activeObjective: request.activeObjective,
+    successCriteria: request.successCriteria,
+  });
+  const decision = evaluateCompletionContract({
+    contract: generated?.contract,
+    evidence: request.evidence,
+    snapshot: request.snapshot,
+    candidateSource: request.candidateSource,
+    summary: request.summary,
+  });
+  return { generated, decision };
+}

--- a/apps/extension/src/background/agent/loop.ts
+++ b/apps/extension/src/background/agent/loop.ts
@@ -89,13 +89,12 @@ import {
   evaluateCompletionSummaryPreflight,
   evaluateCompletionTaskContractPreflight,
   evaluateCompletionWorkflowContractPreflight,
-  evaluateCompletionContract,
-  generateCompletionContract,
   type CompletionCandidateSource,
   type CompletionEnvelope,
   type CompletionEvaluation,
   type TrustedCompletionCandidate,
 } from "./completion-kernel";
+import { evaluateGeneratedCompletionCandidate } from "./completion-evaluation-service";
 import {
   TURN_CHECKPOINT_VERSION,
   turnCheckpointKey,
@@ -164,6 +163,7 @@ import {
   clarificationRequestStep,
 } from "./agent-interaction-steps";
 import {
+  annotateCompletedPlanSubtasksForAcceptedDone,
   buildCompletedPlanStepSummaries,
   buildFailedPlanStep,
   buildPlanMonitorReplanMessage,
@@ -1701,13 +1701,10 @@ export class AgentLoop {
     this.completeTaskUi(summary);
 
     if (this.taskId && this.planSubtasks.length > 0) {
-      for (const sub of this.planSubtasks) {
-        if (!sub.result) sub.result = "Completed";
-      }
-      this.planSubtasks[this.planSubtasks.length - 1].result = summary.slice(
-        0,
-        200,
-      );
+      annotateCompletedPlanSubtasksForAcceptedDone({
+        subtasks: this.planSubtasks,
+        summary,
+      });
 
       const completionMessage = successfulTaskCompletionMessage({
         taskId: this.taskId,
@@ -2333,11 +2330,15 @@ export class AgentLoop {
   ): CompletionEvaluation {
     this.refreshCompletionEvidenceFromSnapshot("candidate_evaluation");
     const completionContext = this.getActiveCompletionContext();
-    const generated = generateCompletionContract({
+    const snapshot = this.context.getSnapshot();
+    const { generated, decision } = evaluateGeneratedCompletionCandidate({
       userRequest: this.originalQuery,
-      snapshot: this.context.getSnapshot(),
+      snapshot,
       activeObjective: completionContext.activeObjective,
       successCriteria: completionContext.successCriteria,
+      evidence: this.completionEvidence.toArray(),
+      candidateSource: source,
+      summary,
     });
     this.traceRecorder?.recordEvent("completion_candidate", {
       turn: this.turnCount,
@@ -2352,13 +2353,6 @@ export class AgentLoop {
         contractKind: generated.contract.kind,
       });
     }
-    const decision = evaluateCompletionContract({
-      contract: generated?.contract,
-      evidence: this.completionEvidence.toArray(),
-      snapshot: this.context.getSnapshot(),
-      candidateSource: source,
-      summary,
-    });
     if (decision.status !== "accepted") {
       this.lastCompletionRejection = decision;
     }
@@ -2368,11 +2362,14 @@ export class AgentLoop {
   private getCompletionRecoveryHintForCurrentState(): string | null {
     this.refreshCompletionEvidenceFromSnapshot("recovery_consult");
     const completionContext = this.getActiveCompletionContext();
-    const generated = generateCompletionContract({
+    const snapshot = this.context.getSnapshot();
+    const { generated, decision } = evaluateGeneratedCompletionCandidate({
       userRequest: this.originalQuery,
-      snapshot: this.context.getSnapshot(),
+      snapshot,
       activeObjective: completionContext.activeObjective,
       successCriteria: completionContext.successCriteria,
+      evidence: this.completionEvidence.toArray(),
+      candidateSource: "model_done",
     });
     if (generated?.notes.length) {
       this.traceRecorder?.recordEvent("completion_contract_repaired", {
@@ -2382,12 +2379,6 @@ export class AgentLoop {
         source: "recovery_consult",
       });
     }
-    const decision = evaluateCompletionContract({
-      contract: generated?.contract,
-      evidence: this.completionEvidence.toArray(),
-      snapshot: this.context.getSnapshot(),
-      candidateSource: "model_done",
-    });
     return buildCompletionRecoveryHint(decision);
   }
 

--- a/apps/extension/src/background/llm/client.ts
+++ b/apps/extension/src/background/llm/client.ts
@@ -517,7 +517,7 @@ function isImageUrlUnsupported(status: number, errorText: string): boolean {
   );
 }
 
-// --- Provider Pool (priority-based failover) ---
+// --- Provider Pool (configured-slot failover) ---
 
 const COOLDOWN_MS = 60_000;
 
@@ -527,25 +527,42 @@ export interface ProviderSlot {
   model: string;
 }
 
-/** Model identifier for a provider pool tier. */
-export interface PoolConfig {
-  openRouterModel: string;
+export interface ProviderPoolSlotInput {
+  provider: ProviderConfig;
+  model: string;
+  cooldownUntil?: number;
 }
 
-/**
- * Provider pool. Currently single-provider (OpenRouter).
- * Retains multi-slot structure for future provider additions.
- */
+export interface ProviderPoolConfig {
+  slots: ProviderPoolSlotInput[];
+}
+
+export function singleProviderPool(
+  provider: ProviderConfig,
+  model: string,
+): ProviderPool {
+  return new ProviderPool({ slots: [{ provider, model }] });
+}
+
+export function openRouterProviderPool(
+  openRouterKey: string,
+  model: string,
+): ProviderPool {
+  return singleProviderPool(openRouterProvider(openRouterKey), model);
+}
+
 export class ProviderPool {
   private slots: ProviderSlot[];
 
-  constructor(openRouterKey: string, config: PoolConfig) {
-    this.slots = [];
-    this.slots.push({
-      provider: openRouterProvider(openRouterKey),
-      cooldownUntil: 0,
-      model: config.openRouterModel,
-    });
+  constructor(config: ProviderPoolConfig) {
+    if (config.slots.length === 0) {
+      throw new Error("ProviderPool requires at least one provider slot");
+    }
+    this.slots = config.slots.map((slot) => ({
+      provider: slot.provider,
+      cooldownUntil: slot.cooldownUntil ?? 0,
+      model: slot.model,
+    }));
   }
 
   /** Returns highest-priority provider not on cooldown */
@@ -553,7 +570,7 @@ export class ProviderPool {
     const now = Date.now();
     return (
       this.slots.find((s) => now >= s.cooldownUntil) ??
-      this.slots[this.slots.length - 1] // OpenRouter as absolute fallback
+      this.slots[this.slots.length - 1]
     );
   }
 
@@ -573,7 +590,6 @@ export class ProviderPool {
     for (let i = idx + 1; i < this.slots.length; i++) {
       if (now >= this.slots[i].cooldownUntil) return this.slots[i];
     }
-    // All downstream are on cooldown — return OpenRouter as absolute fallback
     return this.slots[this.slots.length - 1];
   }
 
@@ -649,9 +665,9 @@ export class LLMClient {
   private provider: ProviderConfig;
   private model: string;
   private openRouterApiKey: string;
-  /** Priority-based provider pool for executor model failover */
+  /** Configured provider pool for executor model failover */
   private executorPool: ProviderPool;
-  /** Priority-based provider pool for planner model failover */
+  /** Configured provider pool for planner model failover */
   private plannerPool: ProviderPool;
   /** Whether the client is currently in planner model tier */
   private _isPlannerTier = false;
@@ -693,10 +709,7 @@ export class LLMClient {
         providerMode: "fireworks-deepseek",
         executorModel: options?.executorModel,
       });
-      this.executorPool = new ProviderPool(fwKey, {
-        openRouterModel: executorModel,
-      });
-      this.executorPool.getSlots()[0].provider = fwProv;
+      this.executorPool = singleProviderPool(fwProv, executorModel);
       this.executorFallbackModel = normalizeExecutorFallbackModel({
         providerMode: "fireworks-deepseek",
         executorModel,
@@ -709,10 +722,7 @@ export class LLMClient {
         providerMode: "moonshot",
         executorModel: options?.executorModel,
       });
-      this.executorPool = new ProviderPool(kimiKey, {
-        openRouterModel: executorModel,
-      });
-      this.executorPool.getSlots()[0].provider = kimiProv;
+      this.executorPool = singleProviderPool(kimiProv, executorModel);
       this.executorFallbackModel = normalizeExecutorFallbackModel({
         providerMode: "moonshot",
         executorModel,
@@ -725,10 +735,7 @@ export class LLMClient {
         providerMode: "xiaomi",
         executorModel: options?.executorModel,
       });
-      this.executorPool = new ProviderPool(xiaomiKey, {
-        openRouterModel: executorModel,
-      });
-      this.executorPool.getSlots()[0].provider = xiaomiProv;
+      this.executorPool = singleProviderPool(xiaomiProv, executorModel);
       this.executorFallbackModel = normalizeExecutorFallbackModel({
         providerMode: "xiaomi",
         executorModel,
@@ -741,10 +748,7 @@ export class LLMClient {
         providerMode: "fireworks",
         executorModel: options?.executorModel,
       });
-      this.executorPool = new ProviderPool(fwKey, {
-        openRouterModel: executorModel,
-      });
-      this.executorPool.getSlots()[0].provider = fwProv;
+      this.executorPool = singleProviderPool(fwProv, executorModel);
       this.executorFallbackModel = normalizeExecutorFallbackModel({
         providerMode: "fireworks",
         executorModel,
@@ -757,10 +761,7 @@ export class LLMClient {
         providerMode: "openai-groq",
         executorModel: options?.executorModel,
       });
-      this.executorPool = new ProviderPool(oaiKey, {
-        openRouterModel: executorModel,
-      });
-      this.executorPool.getSlots()[0].provider = oaiProv;
+      this.executorPool = singleProviderPool(oaiProv, executorModel);
       this.executorFallbackModel = normalizeExecutorFallbackModel({
         providerMode: "openai-groq",
         executorModel,
@@ -779,9 +780,10 @@ export class LLMClient {
         executorModel,
         executorFallbackModel: options?.executorFallbackModel,
       });
-      this.executorPool = new ProviderPool(openRouterApiKey, {
-        openRouterModel: applyNitro(executorModel, nitro),
-      });
+      this.executorPool = openRouterProviderPool(
+        openRouterApiKey,
+        applyNitro(executorModel, nitro),
+      );
       this.executorFallbackModel = applyNitro(executorFallbackModel, nitro);
     }
 
@@ -790,34 +792,22 @@ export class LLMClient {
       const deepseekKey = options?.deepseekApiKey ?? "";
       const deepseekProv = deepseekProvider(deepseekKey);
       const plannerModel = options?.plannerModel || DEEPSEEK_MODEL_PLANNER;
-      this.plannerPool = new ProviderPool(deepseekKey, {
-        openRouterModel: plannerModel,
-      });
-      this.plannerPool.getSlots()[0].provider = deepseekProv;
+      this.plannerPool = singleProviderPool(deepseekProv, plannerModel);
     } else if (mode === "moonshot" && hasMoonshot) {
       const kimiKey = options!.kimiApiKey!;
       const kimiProv = moonshotProvider(kimiKey);
       const plannerModel = options?.plannerModel || MOONSHOT_MODEL_PLANNER;
-      this.plannerPool = new ProviderPool(kimiKey, {
-        openRouterModel: plannerModel,
-      });
-      this.plannerPool.getSlots()[0].provider = kimiProv;
+      this.plannerPool = singleProviderPool(kimiProv, plannerModel);
     } else if (mode === "xiaomi" && hasXiaomi) {
       const xiaomiKey = options!.xiaomiApiKey!;
       const xiaomiProv = xiaomiProvider(xiaomiKey);
       const plannerModel = options?.plannerModel || XIAOMI_MODEL_PLANNER;
-      this.plannerPool = new ProviderPool(xiaomiKey, {
-        openRouterModel: plannerModel,
-      });
-      this.plannerPool.getSlots()[0].provider = xiaomiProv;
+      this.plannerPool = singleProviderPool(xiaomiProv, plannerModel);
     } else if (mode === "fireworks" && hasFireworks) {
       const fwKey = options!.fireworksApiKey!;
       const fwProv = fireworksProvider(fwKey);
       const plannerModel = options?.plannerModel || FIREWORKS_MODEL_PLANNER;
-      this.plannerPool = new ProviderPool(fwKey, {
-        openRouterModel: plannerModel,
-      });
-      this.plannerPool.getSlots()[0].provider = fwProv;
+      this.plannerPool = singleProviderPool(fwProv, plannerModel);
     } else if (
       (mode === "openrouter-groq" || mode === "openai-groq") &&
       hasGroq
@@ -825,27 +815,22 @@ export class LLMClient {
       const groqKey = options!.groqApiKey!;
       const groqProv = groqProvider(groqKey);
       const plannerModel = options?.plannerModel || GROQ_MODEL_PLANNER;
-      this.plannerPool = new ProviderPool(groqKey, {
-        openRouterModel: plannerModel,
-      });
-      this.plannerPool.getSlots()[0].provider = groqProv;
+      this.plannerPool = singleProviderPool(groqProv, plannerModel);
     } else if (mode === "openai-groq" && hasOpenAI) {
       // No Groq key but OpenAI mode — planner uses OpenAI too
       const oaiKey = options!.openaiApiKey!;
       const oaiProv = openAIProvider(oaiKey);
       const plannerModel = options?.plannerModel || OPENAI_MODEL_PLANNER;
-      this.plannerPool = new ProviderPool(oaiKey, {
-        openRouterModel: plannerModel,
-      });
-      this.plannerPool.getSlots()[0].provider = oaiProv;
+      this.plannerPool = singleProviderPool(oaiProv, plannerModel);
     } else {
       // OpenRouter for planner
-      this.plannerPool = new ProviderPool(openRouterApiKey, {
-        openRouterModel: applyNitro(
+      this.plannerPool = openRouterProviderPool(
+        openRouterApiKey,
+        applyNitro(
           options?.plannerModel || MODEL_PLANNER,
           nitro,
         ),
-      });
+      );
     }
 
     // Initialize from executor pool's top priority

--- a/apps/extension/tests/background/completion-status-integrity.test.ts
+++ b/apps/extension/tests/background/completion-status-integrity.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import "../setup";
+import { successfulTaskCompletionMessage } from "../../src/background/agent/agent-broadcast";
+import { annotateCompletedPlanSubtasksForAcceptedDone } from "../../src/background/agent/agent-plan-progress";
+import type { SubtaskSummary } from "../../src/types";
+
+function subtask(
+  status: SubtaskSummary["status"],
+  result?: string,
+): SubtaskSummary {
+  return {
+    description: `${status} subtask`,
+    status,
+    turnsUsed: 1,
+    turnBudget: 3,
+    ...(result ? { result } : {}),
+  };
+}
+
+describe("completion status integrity", () => {
+  test("accepted done only annotates result text for completed subtasks", () => {
+    const subtasks = [
+      subtask("completed"),
+      subtask("running"),
+      subtask("pending"),
+    ];
+
+    annotateCompletedPlanSubtasksForAcceptedDone({
+      subtasks,
+      summary: "Finished the completed work.",
+    });
+
+    expect(subtasks[0].result).toBe("Completed");
+    expect(subtasks[1].result).toBeUndefined();
+    expect(subtasks[2].result).toBeUndefined();
+  });
+
+  test("accepted done does not overwrite a pending final subtask with summary", () => {
+    const subtasks = [
+      subtask("completed", "First step done"),
+      subtask("pending"),
+    ];
+
+    annotateCompletedPlanSubtasksForAcceptedDone({
+      subtasks,
+      summary: "Final task summary",
+    });
+
+    expect(subtasks[0].result).toBe("First step done");
+    expect(subtasks[1].result).toBeUndefined();
+  });
+
+  test("successful task completion reports stale running and pending subtasks as stopped", () => {
+    const message = successfulTaskCompletionMessage({
+      taskId: "task-1",
+      subtasks: [
+        subtask("completed", "Done"),
+        subtask("running"),
+        subtask("pending"),
+        subtask("skipped", "User skipped"),
+        subtask("failed", "Failed"),
+      ],
+      turnCount: 5,
+      totalTimeMs: 1234,
+      summary: "Accepted done",
+      urlHistory: ["https://example.test"],
+    });
+
+    expect(message?.payload.status).toBe("completed");
+    expect(message?.payload.subtaskResults.map((r) => r.status)).toEqual([
+      "completed",
+      "stopped",
+      "stopped",
+      "skipped",
+      "failed",
+    ]);
+    expect(message?.payload.subtaskResults[1].result).toBe("");
+    expect(message?.payload.subtaskResults[2].result).toBe("");
+  });
+});

--- a/apps/extension/tests/background/llm-client.test.ts
+++ b/apps/extension/tests/background/llm-client.test.ts
@@ -537,6 +537,19 @@ describe("complete() payload & response", () => {
     expect(payload.model).toBe("deepseek-v4-pro");
   });
 
+  test("fireworks mode initializes active provider as Fireworks", () => {
+    const client = makeClient({
+      providerMode: "fireworks",
+      fireworksApiKey: "fw-test",
+    });
+
+    expect(client.getCurrentProvider()).toBe("fireworks");
+    expect(client.getActiveProviderInfo()).toEqual({
+      providerId: "fireworks",
+      model: MODEL_EXECUTOR,
+    });
+  });
+
   test("fireworks requests include per-task cache affinity headers", async () => {
     const client = makeClient({
       providerMode: "fireworks",

--- a/apps/extension/tests/background/provider-pool.test.ts
+++ b/apps/extension/tests/background/provider-pool.test.ts
@@ -3,63 +3,79 @@ import {
   ProviderPool,
   MODEL_EXECUTOR,
   MODEL_PLANNER,
-  PoolConfig,
+  openRouterProviderPool,
 } from "../../src/background/llm/client";
+import type { ProviderConfig } from "../../src/background/llm/types";
 
-const EXECUTOR_CONFIG: PoolConfig = {
-  openRouterModel: MODEL_EXECUTOR,
-};
-
-const PLANNER_CONFIG: PoolConfig = {
-  openRouterModel: MODEL_PLANNER,
+const FIREWORKS_PROVIDER: ProviderConfig = {
+  providerId: "fireworks",
+  baseUrl: "https://api.fireworks.ai/inference/v1/chat/completions",
+  apiKey: "fw-key",
+  headers: {},
 };
 
 describe("ProviderPool", () => {
   describe("priority ordering (executor)", () => {
     test("returns OpenRouter as the active provider", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       const slot = pool.getActive();
       expect(slot.provider.providerId).toBe("openrouter");
       expect(slot.model).toBe(MODEL_EXECUTOR);
     });
 
     test("pool has 1 slot", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       expect(pool.getSlots().length).toBe(1);
+    });
+
+    test("can be constructed with a non-OpenRouter provider", () => {
+      const pool = new ProviderPool({
+        slots: [{ provider: FIREWORKS_PROVIDER, model: MODEL_EXECUTOR }],
+      });
+      const slot = pool.getActive();
+      expect(slot.provider.providerId).toBe("fireworks");
+      expect(slot.provider.apiKey).toBe("fw-key");
+      expect(slot.model).toBe(MODEL_EXECUTOR);
+    });
+
+    test("requires at least one provider slot", () => {
+      expect(() => new ProviderPool({ slots: [] })).toThrow(
+        /at least one provider slot/,
+      );
     });
   });
 
   describe("priority ordering (planner)", () => {
     test("returns OpenRouter with planner model", () => {
-      const pool = new ProviderPool("or-key", PLANNER_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_PLANNER);
       const slot = pool.getActive();
       expect(slot.provider.providerId).toBe("openrouter");
       expect(slot.model).toBe(MODEL_PLANNER);
     });
 
     test("planner pool has 1 slot", () => {
-      const pool = new ProviderPool("or-key", PLANNER_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_PLANNER);
       expect(pool.getSlots().length).toBe(1);
     });
   });
 
   describe("cooldown", () => {
-    test("cooldown on single provider still returns it (absolute fallback)", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+    test("cooldown on single provider still returns the configured fallback", () => {
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       pool.cooldown("openrouter");
       const slot = pool.getActive();
       expect(slot.provider.providerId).toBe("openrouter");
     });
 
     test("cooldown for unknown provider is a no-op", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       pool.cooldown("nonexistent");
       const slot = pool.getActive();
       expect(slot.provider.providerId).toBe("openrouter");
     });
 
     test("planner pool cooldown still returns OpenRouter", () => {
-      const pool = new ProviderPool("or-key", PLANNER_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_PLANNER);
       pool.cooldown("openrouter");
       const slot = pool.getActive();
       expect(slot.provider.providerId).toBe("openrouter");
@@ -69,28 +85,43 @@ describe("ProviderPool", () => {
 
   describe("getNextFallback", () => {
     test("returns null for OpenRouter (no more providers)", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       const fallback = pool.getNextFallback("openrouter");
       expect(fallback).toBeNull();
     });
 
     test("returns null for unknown provider", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       const fallback = pool.getNextFallback("nonexistent");
       expect(fallback).toBeNull();
+    });
+
+    test("returns the next configured provider in a multi-slot pool", () => {
+      const openRouterSlot = openRouterProviderPool(
+        "or-key",
+        MODEL_EXECUTOR,
+      ).getActive();
+      const pool = new ProviderPool({
+        slots: [
+          { provider: FIREWORKS_PROVIDER, model: MODEL_EXECUTOR },
+          { provider: openRouterSlot.provider, model: openRouterSlot.model },
+        ],
+      });
+      const fallback = pool.getNextFallback("fireworks");
+      expect(fallback?.provider.providerId).toBe("openrouter");
     });
   });
 
   describe("disableForSession", () => {
     test("isDisabled returns true for disabled provider", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       expect(pool.isDisabled("openrouter")).toBe(false);
       pool.disableForSession("openrouter");
       expect(pool.isDisabled("openrouter")).toBe(true);
     });
 
     test("allDisabled returns true when all slots are disabled", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       expect(pool.allDisabled()).toBe(false);
       pool.disableForSession("openrouter");
       expect(pool.allDisabled()).toBe(true);
@@ -99,19 +130,19 @@ describe("ProviderPool", () => {
 
   describe("model assignment", () => {
     test("provider slot has correct model", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       const slots = pool.getSlots();
       expect(slots[0].model).toBe(MODEL_EXECUTOR);
     });
 
     test("provider URL is correct", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       const slots = pool.getSlots();
       expect(slots[0].provider.baseUrl).toContain("openrouter.ai");
     });
 
     test("API key is correctly assigned", () => {
-      const pool = new ProviderPool("or-key", EXECUTOR_CONFIG);
+      const pool = openRouterProviderPool("or-key", MODEL_EXECUTOR);
       const slots = pool.getSlots();
       expect(slots[0].provider.apiKey).toBe("or-key");
     });

--- a/docs/architecture/agent-loop.md
+++ b/docs/architecture/agent-loop.md
@@ -493,7 +493,7 @@ The agent uses a two-tier architecture with independent provider pools for each 
 
 The Xiaomi provider uses OpenAI-compatible chat completions at `https://api.xiaomimimo.com/v1/chat/completions` with `XIAOMI_API_KEY`. Xiaomi support is scoped to the agent provider stack; it does not add TTS, STT, image generation, or audio support.
 
-Both pools use `ProviderPool` with `PoolConfig` for generic configuration. The `TaskPlanner` also uses the planner pool.
+Both pools use `ProviderPool` with configured provider slots. The `TaskPlanner` also uses the planner pool.
 
 ### Context Distillation
 


### PR DESCRIPTION
## What
- Preserve subtask truth when `done()` is accepted: only completed subtasks receive synthetic result text, and stale `pending`/`running` subtasks are reported as `stopped` instead of `completed`.
- Keep accepted task completion payloads top-level `status: "completed"` while making subtask rows honest.
- Extract the duplicated generated-contract + deterministic-evaluation sequence into `completion-evaluation-service.ts` and reuse it from both live candidate evaluation and recovery hints.
- Rework `ProviderPool` to accept configured provider slots directly, removing the construct-OpenRouter-then-overwrite pattern for Fireworks, Moonshot, Xiaomi, DeepSeek, Groq, and OpenAI modes.
- Update ProviderPool tests and the architecture doc sentence that referenced `PoolConfig`.

## Why
The old completion broadcast path could silently surface unfinished plan subtasks as completed after an accepted `done()` call. The old provider pool constructor also created a misleading OpenRouter slot around non-OpenRouter keys before callers overwrote it, which made provider failover/debugging state harder to trust.

## Impact
- Orchestrator-level accepted completion remains completed; only subtask result rows become more honest when plan state is stale.
- Non-OpenRouter LLM modes now start with their real provider identity in the pool slot.
- No authoritative completion-decider cutover is included here; this is the focused first pass that removes the concrete status bug, ProviderPool misdirection, and duplicated evaluation block.

## Checks
- `corepack pnpm exec vitest run tests/background/provider-pool.test.ts tests/background/llm-client.test.ts tests/background/completion-status-integrity.test.ts`
- `corepack pnpm nx run extension:typecheck`
- `corepack pnpm nx run extension:lint`
- `corepack pnpm nx run extension:test`